### PR TITLE
Delete hidden line item id input when removing tr

### DIFF
--- a/backend/app/assets/javascripts/admin/admin.js.erb
+++ b/backend/app/assets/javascripts/admin/admin.js.erb
@@ -184,6 +184,7 @@ $(document).ready(function(){
         dataType: 'script',
         success: function(response) {
           el.parents("tr").fadeOut('hide', function() {
+            delete_resource_hidden_id_input($(this));
             $(this).remove();
           });
         },
@@ -194,6 +195,20 @@ $(document).ready(function(){
     }
     return false;
   });
+
+  /**
+   * TODO: Remove when we get to Spree 2.0
+   *
+   * Removes the hidden input associated to the specified <tr>, which contains
+   * the id of the line item.
+   *
+   * Since the line item has been removed through ajax we must remove its hidden
+   * id field as well. Otherwise the controller tries to find it and obviously
+   * fails.
+   **/
+  delete_resource_hidden_id_input = function(tr) {
+    tr.next().remove();
+  };
 
   $('body').on('click', 'a.remove_fields', function() {
     el = $(this);


### PR DESCRIPTION
Fixes https://github.com/openfoodfoundation/openfoodnetwork/issues/1658

This ensures we don't send the id of the line item that got removed
through ajax. If the input is not removed from the DOM the backend tries
to load the line item and fails to find it.

This won't be probably needed in Spree 2.0 as then the
admin/orders/_form template does not seem to add hidden inputs with the
ids of the line items.