### PR TITLE
Fix odd even

### DIFF
--- a/backend/app/controllers/spree/admin/line_items_controller.rb
+++ b/backend/app/controllers/spree/admin/line_items_controller.rb
@@ -23,7 +23,9 @@ module Spree
 
       def destroy
         @line_item.destroy
-        render_order_form
+        respond_with(@line_item) do |format|
+          format.html { render_order_form }
+        end
       end
 
       def update


### PR DESCRIPTION
As it is, Spree always returns the HTML form from a `DELETE /line_items/:id` which gets rendered within a flash error in OFN. That is because returning HTML for a JS ajax call raises a 'parsererror' thus, rendering it in the view as an error.

By doing this change, we force Spree to render the `destroy.js.erb` view. That file contains the bit of jquery needed to rerender the line items form.