### PR TITLE
Removed duplicate open/close adjustments methods.

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -114,22 +114,6 @@ module Spree
         respond_with(@order) { |format| format.html { redirect_to :back } }
       end
 
-      def open_adjustments
-        adjustments = @order.adjustments.where(:state => 'closed')
-        adjustments.update_all(:state => 'open')
-        flash[:success] = t(:all_adjustments_opened)
-
-        respond_with(@order) { |format| format.html { redirect_to :back } }
-      end
-
-      def close_adjustments
-        adjustments = @order.adjustments.where(:state => 'open')
-        adjustments.update_all(:state => 'closed')
-        flash[:success] = t(:all_adjustments_closed)
-
-        respond_with(@order) { |format| format.html { redirect_to :back } }
-      end
-
       private
 
         def load_order


### PR DESCRIPTION
This backports the https://github.com/spree/spree/pull/2947 fix to our Spree fork, which will hopefully help on fixing https://github.com/openfoodfoundation/openfoodnetwork/issues/1712